### PR TITLE
proc: Remove verifiedbootstate flag from /proc/cmdline

### DIFF
--- a/fs/proc/cmdline.c
+++ b/fs/proc/cmdline.c
@@ -2,10 +2,13 @@
 #include <linux/init.h>
 #include <linux/proc_fs.h>
 #include <linux/seq_file.h>
+#include <asm/setup.h>
+
+static char new_command_line[COMMAND_LINE_SIZE];
 
 static int cmdline_proc_show(struct seq_file *m, void *v)
 {
-	seq_printf(m, "%s\n", saved_command_line);
+	seq_printf(m, "%s\n", new_command_line);
 	return 0;
 }
 
@@ -23,6 +26,30 @@ static const struct file_operations cmdline_proc_fops = {
 
 static int __init proc_cmdline_init(void)
 {
+	char *offset_addr, *cmd = new_command_line;
+
+	strcpy(cmd, saved_command_line);
+
+	/*
+	 * Remove 'androidboot.verifiedbootstate' flag from command line seen
+	 * by userspace in order to pass SafetyNet CTS check.
+	 */
+	offset_addr = strstr(cmd, "androidboot.verifiedbootstate=");
+	if (offset_addr) {
+		size_t i, len, offset;
+
+		len = strlen(cmd);
+		offset = offset_addr - cmd;
+
+		for (i = 1; i < (len - offset); i++) {
+			if (cmd[offset + i] == ' ')
+				break;
+		}
+
+		memmove(offset_addr, &cmd[offset + i + 1], len - i - offset);
+	}
+
+
 	proc_create("cmdline", 0, NULL, &cmdline_proc_fops);
 	return 0;
 }


### PR DESCRIPTION
Hide verifiedbootstate from /proc/cmdline in order to fix the failed
SafetyNet CTS check.